### PR TITLE
chore(homebrew): sync .Brewfile-mac with currently installed formulae

### DIFF
--- a/ansible/roles/workstations/files/homebrew/.Brewfile-mac
+++ b/ansible/roles/workstations/files/homebrew/.Brewfile-mac
@@ -15,10 +15,18 @@ brew 'tree'
 # Development
 cask 'arduino'
 # cask 'atom'
+brew 'act'  # run GitHub Actions locally
+brew 'astro'
+brew 'beads'
+brew 'coursier'  # Scala/JVM artifact fetcher
 brew 'd2'  # alternative to mermaid (diagram)
 cask 'dbeaver-community'
 brew 'dive'  # analyze docker images
+brew 'dolt'  # git for data
 cask 'docker'  # brew docker is the cli; cask docker is docker-desktop
+brew 'flock'
+brew 'gascity'
+brew 'gemini-cli'
 cask 'google-cloud-sdk'
 brew 'gh'  # github-cli
 cask 'ghostty'
@@ -36,15 +44,22 @@ brew 'kubectx'
 cask 'lens'
 # brew 'macvim'  # yadr zsh wants me to use macvim instead of vim
 brew 'nmap'
+brew 'node'
+brew 'nvm'
+brew 'podman'
 brew 'postgresql'
 cask 'postman'
+brew 'prek'
 brew 'pyenv'
 cask 'raspberry-pi-imager'
 brew 'rbenv'
+brew 'ripgrep'
+brew 'ruby'
 cask 'sublime-text'
 brew 'telnet'
 brew 'terraform'
 brew 'terragrunt'
+brew 'tmux'
 brew 'tree'
 brew 'vim'
 cask 'visual-studio-code'


### PR DESCRIPTION
## Summary

- Adds 15 formulae that are installed locally but were missing from `.Brewfile-mac`
- Excludes python version-specific packages (`python@3.x`)
- Keeps existing entries and ordering intact; new entries are inserted alphabetically within the Development section

**Added formulae:** `act`, `astro`, `beads`, `coursier`, `dolt`, `flock`, `gascity`, `gemini-cli`, `node`, `nvm`, `podman`, `prek`, `ripgrep`, `ruby`, `tmux`

## Test plan

- [ ] Verify `brew bundle check --file=ansible/roles/workstations/files/homebrew/.Brewfile-mac` passes on a mac with these packages installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)