### PR TITLE
docs(claude-md): improve setup steps, tags, and architecture details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,16 @@
 
 ## What This Is
 
-A personal system bootstrap and configuration automation project using Ansible. It automates developer machine setup (macOS MBP 2022, Linux LEMP9 server) including Zsh configuration, Homebrew packages, Vim, and JetBrains Toolbox.
+A personal system bootstrap and configuration automation project using Ansible. Automates developer machine setup (macOS MBP 2022, Linux LEMP9 server) including Zsh configuration, Homebrew packages, Vim, and JetBrains Toolbox.
 
 ## Commands
 
-All Ansible commands run from the `ansible/` directory with uv.
+All Ansible commands run from the `ansible/` directory.
 
 **Setup (one-time):**
 ```shell
-make build
+mise install   # installs uv via mise
+uv sync        # installs ansible and dependencies
 ```
 
 **Run playbooks:**
@@ -21,7 +22,7 @@ uv run ansible-playbook mbp2022.yml --ask-become-pass --check
 # Full macOS setup
 uv run ansible-playbook mbp2022.yml --ask-become-pass
 
-# Selective tags (e.g., only zsh)
+# Selective tags
 uv run ansible-playbook mbp2022.yml --ask-become-pass --tags "zsh"
 
 # LEMP9 server
@@ -29,6 +30,9 @@ uv run ansible-playbook lemp9.yml --ask-become-pass --tags "apt,zsh"
 
 # Test connectivity
 uv run ansible-playbook test.yml --ask-become-pass
+
+# Gather host facts
+uv run ansible all -m setup
 ```
 
 **Quick Zsh-only copy (no Ansible):**
@@ -36,23 +40,29 @@ uv run ansible-playbook test.yml --ask-become-pass
 cp -r ./ansible/roles/workstations/files/zsh/ ~/
 ```
 
+**Available tags:** `vim`, `apt`, `jetbrains`, `zsh`, `homebrew`
+
 ## Architecture
 
 ### Ansible Structure
 
 - `ansible/mbp2022.yml` — macOS playbook (runs `workstations` role)
 - `ansible/lemp9.yml` — Linux server playbook (runs `common` + `workstations` roles)
-- `ansible/roles/workstations/tasks/` — Task files imported conditionally by OS
-- `ansible/roles/workstations/files/` — Dotfiles and config managed by Ansible
+- `ansible/roles/workstations/tasks/main.yml` — imports task files conditionally by OS and tag
+- `ansible/roles/workstations/files/` — dotfiles and configs deployed by Ansible
 
-Tasks are tagged (e.g., `homebrew`, `zsh`, `vim`, `apt`) for selective execution. OS detection via `ansible_distribution` drives conditional task inclusion.
+OS detection via `ansible_distribution` drives conditional task inclusion (e.g., `apt` and `jetbrains` tasks only run on Debian/Ubuntu/Pop!_OS; `homebrew` zsh install only on MacOSX).
+
+### Inventory
+
+`ansible/inventory` defines hosts `localhost`, `mbp2022`, `lemp9` under the `[python3]` group. All use `ansible_connection=local`. `mbp2022.yml` uses `.venv/bin/python` as the interpreter; `lemp9.yml` uses `/usr/bin/python3`.
 
 ### Zsh Configuration
 
 Located in `ansible/roles/workstations/files/zsh/`:
-- `.zshrc` — Entry point, sources files from `.zsh/`
-- `.zsh/` — Modular configs loaded in order (prefixed numerically: `0_path.zsh`, etc.)
-- `.zsh.before/` / `.zsh.after/` — Hook directories for pre/post configs
+- `.zshrc` — entry point, sources files from `.zsh/`
+- `.zsh/` — modular configs loaded in numeric order (`0_path.zsh`, `0000_before.zsh`, etc.)
+- `.zsh.before/` / `.zsh.after/` — hook directories for pre/post configs
 
 Each tool gets its own file (e.g., `pyenv.zsh`, `nvm.zsh`, `golang.zsh`, `aliases.zsh`).
 
@@ -61,8 +71,4 @@ Each tool gets its own file (e.g., `pyenv.zsh`, `nvm.zsh`, `golang.zsh`, `aliase
 - `ansible/roles/workstations/files/homebrew/.Brewfile-mac` — macOS packages
 - `ansible/roles/workstations/files/homebrew/.Brewfile-linux` — LinuxBrew packages
 
-Ansible copies the appropriate Brewfile to `~/.Brewfile` based on detected OS.
-
-### Inventory
-
-`ansible/inventory` defines three local hosts: `localhost`, `mbp2022`, `lemp9`. All use `ansible_connection=local`.
+Ansible copies the appropriate Brewfile to `~/.Brewfile` based on detected OS, then runs `brew bundle install --global`.


### PR DESCRIPTION
## Summary

- Replaces `make build` with the actual two steps (`mise install` + `uv sync`) matching the README
- Adds `uv run ansible all -m setup` for gathering host facts
- Adds explicit **Available tags** list derived from `main.yml`
- Moves and expands Inventory section with group name, interpreter paths per playbook
- Clarifies OS-conditional task inclusion inline with architecture description
- Removes redundant boilerplate prefix line

## Test plan

- [ ] Verify commands in CLAUDE.md match `ansible/README.md` and `ansible/roles/workstations/tasks/main.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)