### PR TITLE
fix(cmux): allow reset from inside cmux and surface ping errors

### DIFF
--- a/cli/cmd/cmux/reset.go
+++ b/cli/cmd/cmux/reset.go
@@ -14,16 +14,13 @@ var resetCmd = &cobra.Command{
 	Short: "Close all cmux workspaces and rebuild from JSON configs",
 	Long: `Closes every open cmux workspace, then rebuilds from JSON configs.
 
-All workspaces are destroyed — including ad-hoc ones not defined in any config
-file. restore-session is intentionally skipped; this is a clean-slate rebuild.
+All workspaces except the calling one are destroyed — including ad-hoc ones not
+defined in any config file. restore-session is intentionally skipped; this is a
+clean-slate rebuild.
 
-Must be run from outside cmux. Running from inside a cmux workspace will close
-the calling terminal before the rebuild can run.`,
+Safe to run from inside cmux: the active workspace is preserved. All other
+workspaces are closed and rebuilt from JSON configs.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if os.Getenv("CMUX_WORKSPACE_ID") != "" {
-			return fmt.Errorf("must be run from outside cmux — closing workspaces would terminate this process")
-		}
-
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("home dir: %w", err)
@@ -32,6 +29,7 @@ the calling terminal before the rebuild can run.`,
 		return icmux.Reset(icmux.ResetOptions{
 			WorkspacesDir:      filepath.Join(home, ".config", "cmux", "workspaces"),
 			LocalWorkspacesDir: filepath.Join(home, ".config", "cmux", "workspaces.local"),
+			SkipWorkspaceID:    os.Getenv("CMUX_WORKSPACE_ID"),
 		}, &realExecutor{})
 	},
 }

--- a/cli/internal/cmux/start.go
+++ b/cli/internal/cmux/start.go
@@ -65,8 +65,12 @@ func LoadWorkspaces(dir string) ([]WorkspaceConfig, error) {
 //  3. Optionally close conflicting workspaces (--override)
 //  4. Create workspaces from JSON configs
 func Start(opts StartOptions, exec Executor) error {
-	if _, err := exec.Run("cmux", "ping"); err != nil {
-		return fmt.Errorf("cmux is not running: ensure cmux is installed and running")
+	if out, err := exec.Run("cmux", "ping"); err != nil {
+		detail := out
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("cmux is not running (%s): ensure cmux is installed and running", detail)
 	}
 
 	if !opts.NoRestore {
@@ -141,16 +145,25 @@ func listAllWorkspaceIDs(exec Executor) []string {
 type ResetOptions struct {
 	WorkspacesDir      string
 	LocalWorkspacesDir string
+	SkipWorkspaceID    string // if non-empty, skip closing this workspace (allows running from inside cmux)
 }
 
 // Reset closes all open cmux workspaces and rebuilds from JSON configs.
 // restore-session is intentionally skipped — this is a clean-slate rebuild.
+// If SkipWorkspaceID is set, that workspace is preserved (allows running from inside cmux).
 func Reset(opts ResetOptions, exec Executor) error {
-	if _, err := exec.Run("cmux", "ping"); err != nil {
-		return fmt.Errorf("cmux is not running: ensure cmux is installed and running")
+	if out, err := exec.Run("cmux", "ping"); err != nil {
+		detail := out
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("cmux is not running (%s): ensure cmux is installed and running", detail)
 	}
 
 	for _, id := range listAllWorkspaceIDs(exec) {
+		if opts.SkipWorkspaceID != "" && id == opts.SkipWorkspaceID {
+			continue
+		}
 		exec.Run("cmux", "close-workspace", "--workspace", id) //nolint:errcheck
 	}
 

--- a/cli/internal/cmux/start_test.go
+++ b/cli/internal/cmux/start_test.go
@@ -86,6 +86,9 @@ func TestStart_CmuxNotRunning(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "cmux is not running") {
 		t.Fatalf("expected cmux not running error, got %v", err)
 	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("expected underlying error detail in message, got %v", err)
+	}
 }
 
 func TestStart_NoRestore(t *testing.T) {
@@ -236,6 +239,34 @@ func TestReset_CmuxNotRunning(t *testing.T) {
 	err := cmux.Reset(cmux.ResetOptions{WorkspacesDir: t.TempDir()}, f)
 	if err == nil || !strings.Contains(err.Error(), "cmux is not running") {
 		t.Fatalf("expected cmux not running error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("expected underlying error detail in message, got %v", err)
+	}
+}
+
+func TestReset_SkipsCurrentWorkspace(t *testing.T) {
+	f := newFake()
+	f.results["cmux list-workspaces"] = "ws:1 alpha\nws:2 beta"
+
+	if err := cmux.Reset(cmux.ResetOptions{WorkspacesDir: t.TempDir(), SkipWorkspaceID: "ws:1"}, f); err != nil {
+		t.Fatal(err)
+	}
+
+	closed := map[string]bool{}
+	for _, c := range f.calls {
+		if c.cmd == "cmux" && len(c.args) > 0 && c.args[0] == "close-workspace" {
+			wsIdx := indexOf(c.args, "--workspace")
+			if wsIdx >= 0 {
+				closed[c.args[wsIdx+1]] = true
+			}
+		}
+	}
+	if closed["ws:1"] {
+		t.Error("ws:1 should be preserved (SkipWorkspaceID), but was closed")
+	}
+	if !closed["ws:2"] {
+		t.Error("ws:2 should be closed, but was not")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Issue 1 — running inside CMUX**: Removes the hard block on `CMUX_WORKSPACE_ID`. Instead passes it as `SkipWorkspaceID` so the calling workspace is preserved during reset. All other workspaces are still closed and rebuilt from config.
- **Issue 2 — Ghostty ping failure**: Includes the underlying error detail (e.g. `executable file not found` or `connection refused`) in the `cmux is not running` message, so PATH/connectivity problems are diagnosable.

## Test plan

- [ ] `go test ./...` passes (covered by new `TestReset_SkipsCurrentWorkspace` and updated ping error assertions)
- [ ] Run `bscmux reset` from inside CMUX — should skip the active workspace and rebuild all others
- [ ] Run `bscmux reset` from vanilla Ghostty with CMUX running — should work; if `cmux` not in PATH, error now shows the actual cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)